### PR TITLE
Docker-Compose update

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,7 +1,7 @@
 version: '3.9'
 services:
   postgres:
-    image: postgres:latest
+    image: postgres:15
     restart: always
     ports:
       - "5432:5432"


### PR DESCRIPTION
Previously created database depends on postgres:15 it while the latest postgres container is postgres:16. Errors pop up complaining about how the database won't run with the newer version of postgres.